### PR TITLE
chore: Dockerfile に sqlc のインストールを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV GO111MODULE on
 COPY . /app
 
 RUN go install github.com/air-verse/air@latest \
+	&& go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest \
 	&& go mod download && go mod tidy
 
 RUN go build -o /tmp/main .


### PR DESCRIPTION
## 概要

sqlc を使用してコード生成を行うため、Docker コンテナ内に sqlc コマンドをインストールします。

## 変更内容

### 追加

- `github.com/sqlc-dev/sqlc/cmd/sqlc@latest` を Dockerfile にインストール

## 使用方法

コンテナ内で以下のコマンドを実行してコードを生成できます：

```bash
sqlc generate
```

## テスト計画

- [ ] Docker イメージのビルド確認
- [ ] コンテナ内で `sqlc version` コマンドが実行できることを確認

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add installation of `github.com/sqlc-dev/sqlc/cmd/sqlc@latest` to the Dockerfile to enable sqlc code generation inside the container.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e75de5312535e4a15e38b227e01c5e294682d437. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->